### PR TITLE
Improve chat widget responsiveness and markdown rendering

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -32,6 +32,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/assets/css/main.css" />
+  
+  <!-- Markdown rendering with XSS protection -->
+  <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js"></script>
 </head>
 <body>
   <div class="stars"></div>
@@ -129,7 +133,30 @@
         label.textContent = sender;
         const body = document.createElement('div');
         body.className = 'chat-msg-body';
-        body.textContent = text;
+        
+        // Render markdown safely with XSS protection
+        if (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
+          // Configure marked for inline rendering (no block elements like <p>)
+          marked.use({
+            breaks: true,
+            gfm: true
+          });
+          const rawHtml = marked.parse(text, { async: false });
+          const cleanHtml = DOMPurify.sanitize(rawHtml, {
+            ALLOWED_TAGS: ['a', 'strong', 'em', 'code', 'br'],
+            ALLOWED_ATTR: ['href', 'target', 'rel']
+          });
+          body.innerHTML = cleanHtml;
+          // Ensure external links open in new tab
+          body.querySelectorAll('a').forEach(link => {
+            link.setAttribute('target', '_blank');
+            link.setAttribute('rel', 'noopener noreferrer');
+          });
+        } else {
+          // Fallback to plain text if libraries not loaded
+          body.textContent = text;
+        }
+        
         el.appendChild(label);
         el.appendChild(body);
         const msgs = document.getElementById('drb-messages');

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -713,9 +713,9 @@
       position: fixed;
       bottom: 92px;
       right: 24px;
-      width: 360px;
+      width: 420px;
       max-width: calc(100vw - 48px);
-      height: 500px;
+      height: 560px;
       max-height: calc(100vh - 120px);
       background: rgba(10,14,39,0.97);
       border: 1px solid var(--border);
@@ -727,6 +727,26 @@
       overflow: hidden;
     }
     #drb-chat-window.open { display: flex; }
+    
+    /* Mobile: full-screen chat */
+    @media (max-width: 640px) {
+      #drb-chat-window {
+        bottom: 0;
+        right: 0;
+        left: 0;
+        top: 0;
+        width: 100%;
+        max-width: 100%;
+        height: 100%;
+        max-height: 100%;
+        border-radius: 0;
+        border: none;
+      }
+      #drb-chat-btn {
+        bottom: 16px;
+        right: 16px;
+      }
+    }
 
     .chat-header {
       display: flex;
@@ -780,6 +800,18 @@
       border-radius: 12px;
       white-space: pre-wrap;
       word-break: break-word;
+    }
+    .chat-msg-body a {
+      color: var(--cyan);
+      text-decoration: underline;
+      transition: opacity 0.2s;
+    }
+    .chat-msg-body a:hover {
+      opacity: 0.8;
+    }
+    .chat-msg-right .chat-msg-body a {
+      color: rgba(255,255,255,0.9);
+      text-decoration: underline;
     }
     .chat-msg-right .chat-msg-body {
       background: var(--blue);


### PR DESCRIPTION
## Changes

### Responsiveness Improvements
- **Desktop**: Increased chat window size from 360x500px to 420x560px for better readability
- **Mobile**: Made chat widget full-screen to prevent overflow and improve UX on small screens
- Adjusted positioning for mobile (bottom-right button repositioned)

### Markdown Rendering
- Added **marked.js** (v11.1.1) for markdown parsing
- Added **DOMPurify** (v3.0.8) for XSS protection
- Updated message rendering to safely convert markdown to HTML
- Allowed tags: `a`, `strong`, `em`, `code`, `br`
- External links automatically open in new tab with `noopener noreferrer`

### Styling
- Added link styling for markdown rendered content
- Different colors for user vs bot messages
- Hover effects on links

## Screenshots
The chat widget now properly renders markdown links like:
```
[Telegram](https://t.me/+J2c-wexHmCJmOThI)
[X](https://x.com/DRBTaskForce)
```

## Testing
- ✅ Build passes (`npm run build`)
- ✅ Desktop sizing improved
- ✅ Mobile full-screen mode works
- ✅ Markdown links render properly
- ✅ XSS protection via DOMPurify

Fixes #6