### PR TITLE
Change PDF buttons to preview-first with separate download links

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1132,9 +1132,31 @@
     }
     .download-grid {
       display: flex;
-      gap: 12px;
+      gap: 16px;
       justify-content: center;
       flex-wrap: wrap;
+    }
+    .download-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+    }
+    .download-description {
+      font-size: 0.8rem;
+      color: var(--muted);
+      margin: 4px 0 0;
+      text-align: center;
+    }
+    .download-link {
+      font-size: 0.8rem;
+      color: var(--cyan);
+      text-decoration: none;
+      border-bottom: 1px solid transparent;
+      transition: border-color 0.2s;
+    }
+    .download-link:hover {
+      border-bottom-color: var(--cyan);
     }
 
     /* ── 404 Page ── */

--- a/src/token/index.njk
+++ b/src/token/index.njk
@@ -12,9 +12,9 @@ description: "Official $DRB token information, contract verification, liquidity 
       <span>Base Chain</span>
     </div>
     <div class="listing-package-link">
-      <a href="/assets/pdfs/DRB_Listing_Packet_v1.pdf" download>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="18" x2="12" y2="12"/><polyline points="9 15 12 18 15 15"/></svg>
-        Exchange Listing Package
+      <a href="/assets/pdfs/DRB_Listing_Packet_v1.pdf" target="_blank" rel="noopener noreferrer">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+        View Exchange Listing Package
       </a>
     </div>
     <h1>DebtReliefBot ($DRB)</h1>
@@ -232,20 +232,30 @@ description: "Official $DRB token information, contract verification, liquidity 
     <h2>Exchange Listing Documentation</h2>
     <p>Professional documentation package ready for exchange applications</p>
 
-    <a href="/assets/pdfs/DRB_Listing_Packet_v1.pdf" download class="download-btn primary">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-      Download Exchange Listing Packet
-    </a>
+    <div class="download-item">
+      <a href="/assets/pdfs/DRB_Listing_Packet_v1.pdf" target="_blank" rel="noopener noreferrer" class="download-btn primary">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+        View Exchange Listing Package
+      </a>
+      <p class="download-description">Preview contract security, locked liquidity, and full deployment details</p>
+      <a href="/assets/pdfs/DRB_Listing_Packet_v1.pdf" download class="download-link">Download PDF</a>
+    </div>
 
     <div class="download-grid">
-      <a href="/assets/pdfs/DRB_ClankerToken_Full_Source_Code.pdf" download class="download-btn secondary">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-        Token Contract Source Code
-      </a>
-      <a href="/assets/pdfs/DRB_Clanker_LP_Locker_Full_Source_Code.pdf" download class="download-btn secondary">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-        LP Locker Source Code
-      </a>
+      <div class="download-item">
+        <a href="/assets/pdfs/DRB_ClankerToken_Full_Source_Code.pdf" target="_blank" rel="noopener noreferrer" class="download-btn secondary">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+          View Token Contract Source Code
+        </a>
+        <a href="/assets/pdfs/DRB_ClankerToken_Full_Source_Code.pdf" download class="download-link">Download PDF</a>
+      </div>
+      <div class="download-item">
+        <a href="/assets/pdfs/DRB_Clanker_LP_Locker_Full_Source_Code.pdf" target="_blank" rel="noopener noreferrer" class="download-btn secondary">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          View LP Locker Source Code
+        </a>
+        <a href="/assets/pdfs/DRB_Clanker_LP_Locker_Full_Source_Code.pdf" download class="download-link">Download PDF</a>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Changes

Implements the improvements requested in #20.

### Updated Buttons

**Before:**
- Direct download on click
- Button text: "Download Exchange Listing Packet"

**After:**
- Opens PDF in new tab for preview
- Button text: "View Exchange Listing Package"
- Separate "Download PDF" link underneath
- Added description: "Preview contract security, locked liquidity, and full deployment details"

### Files Changed

**Token Page (/token/index.njk):**
1. **Hero section** - "Exchange Listing Package" button → view-first
2. **Main download section** - "Download Exchange Listing Packet" → "View Exchange Listing Package"
3. **Token Contract Source Code** - Added view button + download link
4. **LP Locker Source Code** - Added view button + download link

### Visual Changes
- Changed download icon to eye icon (👁️) for view buttons
- Added cyan-colored download links below each button
- Added muted description text for the main listing package
- Better visual hierarchy (view → read description → download)

### CSS Updates
- Added `.download-item` wrapper for button + link groups
- Added `.download-description` styling for helper text
- Added `.download-link` styling for download links with hover effect

## Testing
- ✅ Build passes
- ✅ PDFs open in new tab for preview
- ✅ Download links work correctly
- ✅ Responsive layout maintained

## Preview
Users can now:
1. Click "View" button to preview the PDF
2. Read what they're viewing (description)
3. Click "Download PDF" if they want to save it locally

Fixes #20