### PR TITLE
fix(#31): harden /chat with fail-closed rate limiting and optional Turnstile

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -150,7 +150,7 @@
       const API_URL = 'https://drb-chat-worker.drbtaskforce.workers.dev';
 
       // Set your Cloudflare Turnstile site key here (leave empty to disable)
-      const TURNSTILE_SITE_KEY = '';
+      const TURNSTILE_SITE_KEY = '0x4AAAAAAC21QOFi_hrASmct';
 
       let turnstileWidgetId = null;
       let turnstileResolve = null;

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -47,6 +47,9 @@
   <!-- Markdown rendering with XSS protection -->
   <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js"></script>
+
+  <!-- Cloudflare Turnstile (explicit render — initialized by chat widget) -->
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback&render=explicit" async defer></script>
 </head>
 <body>
   <div class="stars"></div>
@@ -130,6 +133,8 @@
       </button>
     </div>
     <div id="drb-messages" class="flex-1 overflow-y-auto p-4 flex flex-col gap-3 min-h-0"></div>
+    <!-- Turnstile invisible widget (rendered here so it inherits chat window z-index) -->
+    <div id="cf-turnstile-container" style="display:none"></div>
     <div class="flex gap-2 px-3.5 py-3 border-t border-border-col shrink-0">
       <input id="drb-user-input" type="text" placeholder="Ask about $DRB or Grok..." autocomplete="off"
         class="flex-1 px-3.5 py-2.5 bg-[var(--chat-input-bg)] border border-border-col rounded-[10px] text-text-primary font-body text-[0.85rem] outline-none transition-colors duration-200 placeholder:text-text-muted focus:border-brand-cyan/40" />
@@ -143,6 +148,41 @@
   <script>
     (function () {
       const API_URL = 'https://drb-chat-worker.drbtaskforce.workers.dev';
+
+      // Set your Cloudflare Turnstile site key here (leave empty to disable)
+      const TURNSTILE_SITE_KEY = '';
+
+      let turnstileWidgetId = null;
+      let turnstileResolve = null;
+
+      function onTurnstileToken(token) {
+        if (turnstileResolve) {
+          turnstileResolve(token);
+          turnstileResolve = null;
+        }
+      }
+
+      function initTurnstile() {
+        if (!TURNSTILE_SITE_KEY || typeof turnstile === 'undefined') return;
+        turnstileWidgetId = turnstile.render('#cf-turnstile-container', {
+          sitekey: TURNSTILE_SITE_KEY,
+          callback: onTurnstileToken,
+          'error-callback': () => { if (turnstileResolve) { turnstileResolve(null); turnstileResolve = null; } },
+          execution: 'execute',
+          size: 'invisible',
+        });
+      }
+
+      // Called by Turnstile script once loaded
+      window.onloadTurnstileCallback = initTurnstile;
+
+      function getTurnstileToken() {
+        if (!turnstileWidgetId) return Promise.resolve(null);
+        return new Promise(resolve => {
+          turnstileResolve = resolve;
+          turnstile.execute(turnstileWidgetId);
+        });
+      }
 
       function updateChatPosition() {
         const w = document.getElementById('drb-chat-window');
@@ -213,10 +253,13 @@
         addMessage('DRB', 'Thinking…', 'left', thinkingId);
         btn.disabled = true;
         try {
+          const turnstileToken = await getTurnstileToken();
+          const payload = { message: msg };
+          if (turnstileToken) payload.turnstileToken = turnstileToken;
           const res = await fetch(API_URL + '/chat', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ message: msg }),
+            body: JSON.stringify(payload),
           });
           const raw = await res.text();
           let data = {};
@@ -235,6 +278,7 @@
           addMessage('DRB', 'Could not reach the chat service.', 'left');
         } finally {
           btn.disabled = false;
+          if (turnstileWidgetId) turnstile.reset(turnstileWidgetId);
         }
       }
 

--- a/workers/chat-worker.js
+++ b/workers/chat-worker.js
@@ -3,9 +3,11 @@
  * Cloudflare Worker — proxies requests to xAI Grok API
  *
  * Environment variables (set in Cloudflare dashboard or wrangler.toml secrets):
- *   XAI_API_KEY  — your xAI API key from https://console.x.ai/
- *   MODEL        — optional, defaults to "grok-3"
- *   ALLOWED_ORIGIN — optional, defaults to https://drbtaskforce.github.io
+ *   XAI_API_KEY       — your xAI API key from https://console.x.ai/
+ *   MODEL             — optional, defaults to "grok-3"
+ *   ALLOWED_ORIGIN    — optional, defaults to https://drbtaskforce.github.io
+ *   RATE_LIMITER      — required: Cloudflare Rate Limiting binding (fail-closed if missing)
+ *   TURNSTILE_SECRET  — optional: Cloudflare Turnstile secret key; enables widget verification
  */
 
 
@@ -284,12 +286,38 @@ export default {
       return jsonResponse({ error: 'API key not configured' }, 500, origin);
     }
 
-    // Rate limit by IP
-    if (env.RATE_LIMITER) {
-      const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
-      const { success } = await env.RATE_LIMITER.limit({ key: ip });
-      if (!success) {
-        return jsonResponse({ error: 'Too many requests. Please wait a moment.' }, 429, origin);
+    // Rate limit by IP — fail closed: if no RATE_LIMITER binding, reject the request
+    if (!env.RATE_LIMITER) {
+      return jsonResponse({ error: 'Service unavailable (rate limiter not configured)' }, 503, origin);
+    }
+    const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+    const { success: rateOk } = await env.RATE_LIMITER.limit({ key: ip });
+    if (!rateOk) {
+      return jsonResponse({ error: 'Too many requests. Please wait a moment.' }, 429, origin);
+    }
+
+    // Turnstile verification — if TURNSTILE_SECRET is set, validate the cf-turnstile-response header
+    if (env.TURNSTILE_SECRET) {
+      const token = request.headers.get('cf-turnstile-response') || body?.turnstileToken || '';
+      if (!token) {
+        return jsonResponse({ error: 'Missing Turnstile token' }, 403, origin);
+      }
+      const form = new FormData();
+      form.append('secret', env.TURNSTILE_SECRET);
+      form.append('response', token);
+      form.append('remoteip', ip);
+      let tsResult;
+      try {
+        const tsRes = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+          method: 'POST',
+          body: form,
+        });
+        tsResult = await tsRes.json();
+      } catch {
+        return jsonResponse({ error: 'Turnstile verification failed' }, 502, origin);
+      }
+      if (!tsResult.success) {
+        return jsonResponse({ error: 'Turnstile challenge failed' }, 403, origin);
       }
     }
 


### PR DESCRIPTION
Closes #31

## Summary

- **Rate limiter is now fail-closed**: returns `503` if the `RATE_LIMITER` binding isn't configured — previously it silently skipped rate limiting, leaving the endpoint unprotected
- **Optional Turnstile verification**: if `TURNSTILE_SECRET` is set, the worker validates a Cloudflare Turnstile token (from `cf-turnstile-response` header or `body.turnstileToken`) before hitting the xAI API — returns `403` on missing/failed token
- Updated header comment to document all env vars (`RATE_LIMITER` required, `TURNSTILE_SECRET` optional)

## Test plan

- [ ] Verify `/chat` returns `503` when `RATE_LIMITER` binding is absent
- [ ] Verify `/chat` returns `429` after exceeding rate limit
- [ ] Verify `/chat` works normally with a valid `RATE_LIMITER` binding and no `TURNSTILE_SECRET`
- [ ] When `TURNSTILE_SECRET` is set: verify `403` on missing token, `403` on invalid token, `200` on valid token

🤖 Generated with [Claude Code](https://claude.com/claude-code)